### PR TITLE
Add preview support

### DIFF
--- a/cargo-obs-build/Cargo.lock
+++ b/cargo-obs-build/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-obs-build"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/cargo-obs-build/Cargo.toml
+++ b/cargo-obs-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-obs-build"
 description = "A CLI tool used to build the libobs library and put it in the taregt directory"
-version = "0.1.7"
+version = "0.1.8"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/joshprk/libobs-rs"

--- a/cargo-obs-build/src/main.rs
+++ b/cargo-obs-build/src/main.rs
@@ -145,6 +145,7 @@ fn build_obs(release: ReleaseInfo, build_out: &Path) -> anyhow::Result<()> {
         "obs-webrtc",
         "obs-websocket",
         "decklink",
+        "qt6"
     ];
 
     println!("{} unnecessary files...", "Cleaning up".red());
@@ -156,7 +157,11 @@ fn build_obs(release: ReleaseInfo, build_out: &Path) -> anyhow::Result<()> {
         let entry = entry.unwrap();
         let path = entry.path();
 
-        if to_exclude.iter().any(|e| path.file_name().is_some_and(|x| x.to_string_lossy().contains(e) || x.to_string_lossy() == *e)) {
+        if to_exclude.iter().any(|e| path.file_name().is_some_and(|x|{
+            let x_l = x.to_string_lossy().to_lowercase();
+
+            x_l.contains(e) || x_l == *e
+        })) {
             println!("Deleting: {}", path.display().to_string().red());
             if path.is_dir() {
                 fs::remove_dir_all(path).unwrap();

--- a/libobs-segfault-trace/src/main.rs
+++ b/libobs-segfault-trace/src/main.rs
@@ -14,7 +14,7 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use crash_handler::CrashHandler;
-use libobs_wrapper::{context::ObsContext, data::ObsData, encoders::ObsContextEncoders, utils::{AudioEncoderInfo, ObsPath, OutputInfo, SourceInfo, StartupInfo, VideoEncoderInfo}};
+use libobs_wrapper::{context::ObsContext, data::ObsData, encoders::ObsContextEncoders, utils::{AudioEncoderInfo, ObsPath, OutputInfo, StartupInfo, VideoEncoderInfo}};
 use std::{
     env::{args, current_dir, current_exe}, fs::File, io::Write, path::PathBuf, thread, time::{Duration, SystemTime, UNIX_EPOCH}
 };
@@ -277,12 +277,13 @@ pub fn run_basic_obs() -> Result<()> {
         .set_string("window", "")
         .set_bool("capture_cursor", true);
 
-    let video_source_info = SourceInfo::new(
+    /*let video_source_info = SourceInfo::new(
         "game_capture",
         "video_source",
         Some(video_source_data),
         None,
     );
+    */
 
     // Register the source and record
     //output.source(video_source_info, 0)?;

--- a/libobs-sources/src/lib.rs
+++ b/libobs-sources/src/lib.rs
@@ -33,3 +33,4 @@
 pub mod windows;
 
 pub mod encoders;
+pub mod output;

--- a/libobs-sources/src/output.rs
+++ b/libobs-sources/src/output.rs
@@ -1,0 +1,59 @@
+use libobs_source_macro::obs_object_builder;
+
+macro_rules! new_output_builder {
+    ($builder:ident, $output_type:literal) => {
+        #[obs_object_builder($output_type)]
+        pub struct $builder {
+            #[obs_property(type_t = "string")]
+            /// The path the recording should be saved to
+            path: String,
+
+            #[obs_property(type_t = "int")]
+            bitrate: i32,
+
+            #[obs_property(type_t = "int")]
+            codec_type: i32,
+
+            #[obs_property(type_t = "string")]
+            // Custom Arguments for the muxer to use
+            muxer_settings: String,
+
+            #[obs_property(type_t = "int")]
+            // The maximum time in seconds that the recording should hold
+            max_time_sec: i32,
+
+            #[obs_property(type_t = "int")]
+            // The maximum size in megabytes that the recording should hold
+            max_size_mb: i32,
+
+            #[obs_property(type_t = "bool")]
+            /// Whether the recording should be split into multiple files and merged later
+            split_file: bool,
+
+            #[obs_property(type_t = "bool")]
+            /// Whether it should be permitted to overwrite the old file
+            allow_overwrite: bool,
+
+            #[obs_property(type_t = "string")]
+            /// The directory the recording should be saved to
+            directory: String,
+
+            #[obs_property(type_t = "string")]
+            /// The format to use for the file name of the recording.
+            /// e.g. "%CCYY-%MM-%DD %hh-%mm-%ss"
+            /// Code for formatting can be found here: https://github.com/obsproject/obs-studio/blob/5854f3b9e5861246ea57dd4a26d3d847a8552c4b/libobs/util/platform.c#L715
+            format: String,
+
+            #[obs_property(type_t = "string")]
+            /// The extension to use for the file name of the recording (without the dot, e.g. "mpr")
+            extension: String,
+
+            #[obs_property(type_t = "bool")]
+            /// Whether spaces are allowed in the file name
+            allow_spaces: bool,
+        }
+    };
+}
+
+new_output_builder!(FFmpegMuxerOutput, "ffmpeg_muxer");
+new_output_builder!(ReplayBufferOutput, "replay_buffer");

--- a/libobs-wrapper/src/context.rs
+++ b/libobs-wrapper/src/context.rs
@@ -270,7 +270,6 @@ impl ObsContext {
     pub fn display(&mut self, data: ObsDisplayCreationData) -> Result<&mut ObsDisplay, ObsError> {
         let display = ObsDisplay::new(
             &self.vertex_buffers,
-            &self.active_scene,
             data,
         ).map_err(|e| ObsError::DisplayCreationError(e))?;
 

--- a/libobs-wrapper/src/data/output/mod.rs
+++ b/libobs-wrapper/src/data/output/mod.rs
@@ -18,6 +18,9 @@ use crate::{
 
 use super::ObsData;
 
+mod replay_buffer;
+pub use replay_buffer::*;
+
 #[derive(Debug, Getters)]
 #[skip_new]
 pub struct ObsOutput {

--- a/libobs-wrapper/src/data/output/replay_buffer.rs
+++ b/libobs-wrapper/src/data/output/replay_buffer.rs
@@ -1,0 +1,67 @@
+use std::{ffi::c_char, mem::MaybeUninit, path::{Path, PathBuf}};
+
+use libobs::{calldata_get_string, calldata_t, obs_output_get_proc_handler, proc_handler_call};
+
+use crate::utils::{ObsError, ObsString};
+
+use super::ObsOutput;
+
+pub trait ReplayBufferOutput {
+    fn save_buffer(&self) -> Result<Box<Path>, ObsError>;
+}
+
+impl ReplayBufferOutput for ObsOutput {
+    fn save_buffer(&self) -> Result<Box<Path>, ObsError> {
+        let ph = unsafe { obs_output_get_proc_handler(self.output.0) };
+        if ph.is_null() {
+            return Err(ObsError::OutputSaveBufferFailure(
+                "Failed to get proc handler.".to_string(),
+            ));
+        }
+
+        let name = ObsString::new("save");
+        let call_success = unsafe {
+            let mut calldata = MaybeUninit::<calldata_t>::zeroed();
+            proc_handler_call(ph, name.as_ptr(), calldata.as_mut_ptr())
+        };
+
+        if !call_success {
+            return Err(ObsError::OutputSaveBufferFailure(
+                "Failed to call proc handler.".to_string(),
+            ));
+        }
+
+        let func_get = ObsString::new("get_last_replay");
+        let last_replay = unsafe {
+            let mut calldata = MaybeUninit::<calldata_t>::zeroed();
+            let success = proc_handler_call(ph, func_get.as_ptr(), calldata.as_mut_ptr());
+
+            if !success {
+                return Err(ObsError::OutputSaveBufferFailure(
+                    "Failed to call get_last_replay.".to_string(),
+                ));
+            }
+
+            calldata.assume_init()
+        };
+
+        let path_get = ObsString::new("path");
+        let path = unsafe {
+            let mut s = MaybeUninit::<*const c_char>::uninit();
+
+            let res = calldata_get_string(&last_replay, path_get.as_ptr(), s.as_mut_ptr());
+            if !res {
+                return Err(ObsError::OutputSaveBufferFailure(
+                    "Failed to get path from last replay.".to_string(),
+                ));
+            }
+
+            let s: *const c_char = s.assume_init();
+            let path = std::ffi::CStr::from_ptr(s).to_str().unwrap();
+
+            PathBuf::from(path)
+        };
+
+        Ok(path.into_boxed_path())
+    }
+}

--- a/libobs-wrapper/src/display/creation_data.rs
+++ b/libobs-wrapper/src/display/creation_data.rs
@@ -17,7 +17,6 @@ pub struct ObsDisplayCreationData {
     pub(super) adapter: u32,
     pub(super) backbuffers: u32,
     pub(super) background_color: u32,
-    pub(super) scale: f32,
 }
 
 impl ObsDisplayCreationData {
@@ -33,8 +32,7 @@ impl ObsDisplayCreationData {
             height,
             adapter: 0,
             backbuffers: 0,
-            background_color: 0,
-            scale: 1.0,
+            background_color: 0
         }
     }
 
@@ -60,11 +58,6 @@ impl ObsDisplayCreationData {
 
     pub fn set_background_color(mut self, background_color: u32) -> Self {
         self.background_color = background_color;
-        self
-    }
-
-    pub fn set_scale(mut self, scale: f32) -> Self {
-        self.scale = scale;
         self
     }
 

--- a/libobs-wrapper/src/display/mod.rs
+++ b/libobs-wrapper/src/display/mod.rs
@@ -38,10 +38,9 @@ pub struct ObsDisplay {
 
 unsafe extern "C" fn render_display(data: *mut c_void, _cx: u32, _cy: u32) {
     let s = &mut *(data as *mut ObsDisplay);
-    let m = &s.manager;
 
-    let (x, y) = m.get_pos();
-    let (width, height) = m.get_size();
+    let (x, y) = s.get_pos();
+    let (width, height) = s.get_size();
 
     let mut ovi: obs_video_info = std::mem::zeroed();
     obs_get_video_info(&mut ovi);

--- a/libobs-wrapper/src/display/mod.rs
+++ b/libobs-wrapper/src/display/mod.rs
@@ -9,7 +9,7 @@ mod window_manager;
 pub(crate) use buffers::*;
 pub use creation_data::*;
 pub use enums::*;
-pub use window_manager::{DisplayWindowManager, WindowPositionTrait};
+pub use window_manager::*;
 
 use std::{
     ffi::c_void,
@@ -117,7 +117,7 @@ impl ObsDisplay {
     }
 
     /// Adds draw callbacks to the display.
-    pub fn create(&mut self) -> () {
+    pub fn create(&mut self) {
         if self.is_initialized {
             return;
         }

--- a/libobs-wrapper/src/display/mod.rs
+++ b/libobs-wrapper/src/display/mod.rs
@@ -12,17 +12,13 @@ pub use enums::*;
 pub use window_manager::{DisplayWindowManager, WindowPositionTrait};
 
 use std::{
-    ffi::{c_void, CString},
+    ffi::c_void,
     sync::atomic::AtomicUsize,
 };
 
 use libobs::{
-    gs_draw, gs_draw_mode_GS_TRISTRIP, gs_effect_get_param_by_name, gs_effect_get_technique,
-    gs_effect_set_vec4, gs_load_vertexbuffer, gs_matrix_identity, gs_matrix_pop, gs_matrix_push,
-    gs_matrix_scale3f, gs_ortho, gs_projection_pop, gs_projection_push, gs_set_viewport, gs_technique_begin, gs_technique_begin_pass, gs_technique_end,
-    gs_technique_end_pass, gs_viewport_pop, gs_viewport_push, obs_base_effect_OBS_EFFECT_SOLID,
-    obs_get_base_effect, obs_get_video_info, obs_render_main_texture,
-    obs_video_info, vec4_create, vec4_set,
+    gs_ortho, gs_projection_pop, gs_projection_push, gs_set_viewport, gs_viewport_pop, gs_viewport_push, obs_get_video_info, obs_render_main_texture,
+    obs_video_info,
 };
 
 use crate::unsafe_send::WrappedObsDisplay;
@@ -38,37 +34,6 @@ pub struct ObsDisplay {
 
     // Keep for window
     manager: DisplayWindowManager,
-}
-
-unsafe fn draw_backdrop(buffers: &VertexBuffers, width: f32, height: f32) {
-    let solid = obs_get_base_effect(obs_base_effect_OBS_EFFECT_SOLID);
-    let c = CString::new("color").unwrap();
-
-    let color = gs_effect_get_param_by_name(solid, c.as_ptr());
-    let s = CString::new("Solid").unwrap();
-    let tech = gs_effect_get_technique(solid, s.as_ptr());
-
-    let mut color_val = vec4_create();
-    vec4_set(&mut color_val, 0.0, 0.0, 0.0, 1.0);
-    gs_effect_set_vec4(color, &color_val);
-
-    gs_technique_begin(tech);
-    gs_technique_begin_pass(tech, 0);
-    gs_matrix_push();
-    gs_matrix_identity();
-    gs_matrix_scale3f(width as f32, height as f32, 1.0);
-
-    let box_v = buffers.box_buffer.lock().unwrap();
-    gs_load_vertexbuffer(box_v.0);
-    drop(box_v);
-
-    gs_draw(gs_draw_mode_GS_TRISTRIP, 0, 0);
-
-    gs_matrix_pop();
-    gs_technique_end_pass(tech);
-    gs_technique_end(tech);
-
-    gs_load_vertexbuffer(std::ptr::null_mut());
 }
 
 unsafe extern "C" fn render_display(data: *mut c_void, _cx: u32, _cy: u32) {

--- a/libobs-wrapper/src/display/mod.rs
+++ b/libobs-wrapper/src/display/mod.rs
@@ -7,40 +7,37 @@ mod enums;
 mod window_manager;
 
 pub(crate) use buffers::*;
-pub use enums::*;
 pub use creation_data::*;
-use window_manager::DisplayWindowManager;
+pub use enums::*;
+pub use window_manager::{DisplayWindowManager, WindowPositionTrait};
 
 use std::{
     ffi::{c_void, CString},
-    sync::{atomic::AtomicUsize, Arc, Mutex},
+    sync::atomic::AtomicUsize,
 };
 
 use libobs::{
     gs_draw, gs_draw_mode_GS_TRISTRIP, gs_effect_get_param_by_name, gs_effect_get_technique,
     gs_effect_set_vec4, gs_load_vertexbuffer, gs_matrix_identity, gs_matrix_pop, gs_matrix_push,
-    gs_matrix_scale3f, gs_ortho, gs_projection_pop, gs_projection_push, gs_reset_viewport,
-    gs_set_viewport, gs_technique_begin, gs_technique_begin_pass, gs_technique_end,
+    gs_matrix_scale3f, gs_ortho, gs_projection_pop, gs_projection_push, gs_set_viewport, gs_technique_begin, gs_technique_begin_pass, gs_technique_end,
     gs_technique_end_pass, gs_viewport_pop, gs_viewport_push, obs_base_effect_OBS_EFFECT_SOLID,
-    obs_display_size, obs_get_base_effect, obs_get_video_info,
-    obs_render_main_texture_src_color_only, obs_video_info, vec4_create, vec4_set,
+    obs_get_base_effect, obs_get_video_info, obs_render_main_texture,
+    obs_video_info, vec4_create, vec4_set,
 };
 
-use crate::unsafe_send::{WrappedObsDisplay, WrappedObsScene};
+use crate::unsafe_send::WrappedObsDisplay;
 
 static ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 #[derive(Debug)]
 pub struct ObsDisplay {
     display: WrappedObsDisplay,
     id: usize,
-    scale: f32,
-    x: u32,
-    y: u32,
-    width: u32,
-    height: u32,
-    buffers: VertexBuffers,
-    active_scene: Arc<Mutex<Option<WrappedObsScene>>>,
-    manager: DisplayWindowManager
+
+    _buffers: VertexBuffers,
+    is_initialized: bool,
+
+    // Keep for window
+    manager: DisplayWindowManager,
 }
 
 unsafe fn draw_backdrop(buffers: &VertexBuffers, width: f32, height: f32) {
@@ -73,89 +70,34 @@ unsafe fn draw_backdrop(buffers: &VertexBuffers, width: f32, height: f32) {
 
     gs_load_vertexbuffer(std::ptr::null_mut());
 }
-unsafe extern "C" fn render_display_old(data: *mut c_void, _cx: u32, _cy: u32) {
-    obs_render_main_texture_src_color_only();
-}
+
 unsafe extern "C" fn render_display(data: *mut c_void, _cx: u32, _cy: u32) {
-    log::trace!("Rendering display...");
     let s = &mut *(data as *mut ObsDisplay);
+    let m = &s.manager;
+
+    let (x, y) = m.get_pos();
+    let (width, height) = m.get_size();
 
     let mut ovi: obs_video_info = std::mem::zeroed();
-
     obs_get_video_info(&mut ovi);
-
-    log::trace!("Setting width...");
-    s.width = (s.scale * ovi.base_width as f32) as u32;
-    s.height = (s.scale * ovi.base_height as f32) as u32;
 
     gs_viewport_push();
     gs_projection_push();
 
-    let display = s.display.0;
-    let mut width: u32 = 0;
-    let mut height: u32 = 0;
-
-    obs_display_size(display, &mut width, &mut height);
-    let right = width as f32 - s.x as f32;
-    let bottom = height as f32 - s.x as f32;
-
-    gs_ortho(-(s.x as f32), right, -(s.y as f32), bottom, -100.0, 100.0);
-
-    //window->ui->preview->DrawOverflow();
-
-    /* --------------------------------------- */
-    log::trace!("Ortho...");
     gs_ortho(
-        0.0,
+        0.0f32,
         ovi.base_width as f32,
-        0.0,
+
+        0.0f32,
         ovi.base_height as f32,
-        -100.0,
-        100.0,
+
+        -100.0f32,
+        100.0f32,
     );
-    gs_set_viewport(s.x as i32, s.y as i32, s.width as i32, s.height as i32);
-    log::trace!("Backdrop...");
-    draw_backdrop(&s.buffers, ovi.base_width as f32, ovi.base_height as f32);
+    gs_set_viewport(x as i32, y as i32, width as i32, height as i32);
+    //draw_backdrop(&s.buffers, ovi.base_width as f32, ovi.base_height as f32);
 
-    //let scene = s.active_scene.lock().unwrap();
-    /*if let Some(s) = scene.as_ref() {
-        let t = &s.0;
-        if !(*t).is_null() {
-            let source = obs_scene_get_source(*t);
-            if source != std::ptr::null_mut() {
-                obs_source_video_render(source);
-            }
-        }
-    } else {*/
-    log::trace!("Render texture...");
-    obs_render_main_texture_src_color_only();
-    // }
-
-    log::trace!("Load buffer...");
-    gs_load_vertexbuffer(std::ptr::null_mut());
-
-    /* --------------------------------------- */
-
-    gs_ortho(-(s.x as f32), right, -(s.y as f32), bottom, -100.0, 100.0);
-    gs_reset_viewport();
-
-    /*	if (window->drawSafeAreas) {
-        RenderSafeAreas(window->actionSafeMargin, targetCX, targetCY);
-        RenderSafeAreas(window->graphicsSafeMargin, targetCX, targetCY);
-        RenderSafeAreas(window->fourByThreeSafeMargin, targetCX,
-                targetCY);
-        RenderSafeAreas(window->leftLine, targetCX, targetCY);
-        RenderSafeAreas(window->topLine, targetCX, targetCY);
-        RenderSafeAreas(window->rightLine, targetCX, targetCY);
-    }
-     */
-
-    //window->ui->preview->DrawSceneEditing();
-    /*
-       if (window->drawSpacingHelpers)
-           window->ui->preview->DrawSpacingHelpers();
-    */
-    /* --------------------------------------- */
+    obs_render_main_texture();
 
     gs_projection_pop();
     gs_viewport_pop();
@@ -163,14 +105,15 @@ unsafe extern "C" fn render_display(data: *mut c_void, _cx: u32, _cy: u32) {
 
 impl ObsDisplay {
     #[cfg(target_family = "windows")]
+    /// Call initialize to ObsDisplay#create the display
     pub fn new(
         buffers: &VertexBuffers,
-        active_scene: &Arc<Mutex<Option<WrappedObsScene>>>,
         data: creation_data::ObsDisplayCreationData,
     ) -> windows::core::Result<Self> {
+        use std::sync::atomic::Ordering;
+
         use creation_data::ObsDisplayCreationData;
         use libobs::gs_window;
-        use std::sync::atomic::Ordering;
         use window_manager::DisplayWindowManager;
 
         let ObsDisplayCreationData {
@@ -178,54 +121,62 @@ impl ObsDisplay {
             y,
             height,
             width,
-            scale,
             parent_window,
             background_color,
             ..
         } = data.clone();
 
-        let manager = DisplayWindowManager::new(
+        let mut manager = DisplayWindowManager::new(
             parent_window.clone(),
             x as i32,
             y as i32,
-            width as i32,
-            height as i32,
+            width,
+            height,
         )?;
 
         let child_handle = manager.get_child_handle();
-        let init_data = data.build(gs_window { hwnd: child_handle.0 });
+        let init_data = data.build(gs_window {
+            hwnd: child_handle.0,
+        });
 
         log::trace!("Creating obs display...");
         let display = unsafe { libobs::obs_display_create(&init_data, background_color) };
 
-        let s = Self {
+        manager.obs_display = Some(WrappedObsDisplay(display));
+        Ok(Self {
             display: WrappedObsDisplay(display),
             manager,
             id: ID_COUNTER.fetch_add(1, Ordering::Relaxed),
-            width,
-            height,
-            scale,
-            x,
-            y,
-            buffers: buffers.clone(),
-            active_scene: active_scene.clone(),
-        };
+            _buffers: buffers.clone(),
+            is_initialized: false,
+        })
+    }
 
-        log::trace!("Adding draw callback...");
+    /// Adds draw callbacks to the display.
+    pub fn create(&mut self) -> () {
+        if self.is_initialized {
+            return;
+        }
+
+        log::trace!("Adding draw callback with display {:?}...", self.display.0);
         unsafe {
             libobs::obs_display_add_draw_callback(
-                display,
+                self.display.0,
                 Some(render_display),
-                std::ptr::addr_of!(s) as *mut _,
+                self as *mut _ as *mut c_void,
             );
         }
 
         log::trace!("Display created!");
-        Ok(s)
+        self.is_initialized = true;
     }
 
     pub fn get_id(&self) -> usize {
         self.id
+    }
+
+    pub fn manager_mut(&mut self) -> &mut DisplayWindowManager {
+        &mut self.manager
     }
 }
 

--- a/libobs-wrapper/src/display/window_manager/mod.rs
+++ b/libobs-wrapper/src/display/window_manager/mod.rs
@@ -119,6 +119,8 @@ pub struct DisplayWindowManager {
     width: u32,
     height: u32,
 
+    scale: f32,
+
     render_at_bottom: bool,
 
     pub(super) obs_display: Option<WrappedObsDisplay>
@@ -217,6 +219,7 @@ impl DisplayWindowManager {
             y,
             width,
             height,
+            scale: 1.0,
             hwnd: WrappedHWND(window),
             should_exit,
             _message_thread: message_thread,

--- a/libobs-wrapper/src/display/window_manager/mod.rs
+++ b/libobs-wrapper/src/display/window_manager/mod.rs
@@ -29,6 +29,8 @@ use windows::{
 use crate::unsafe_send::{WrappedHWND, WrappedObsDisplay};
 
 mod position_trait;
+mod show_hide;
+pub use show_hide::ShowHideTrait;
 pub use position_trait::WindowPositionTrait;
 
 extern "system" fn wndproc(
@@ -120,6 +122,8 @@ pub struct DisplayWindowManager {
     height: u32,
 
     scale: f32,
+
+    is_hidden: bool,
 
     render_at_bottom: bool,
 
@@ -224,6 +228,7 @@ impl DisplayWindowManager {
             should_exit,
             _message_thread: message_thread,
             render_at_bottom: false,
+            is_hidden: false,
             obs_display: None
         })
     }

--- a/libobs-wrapper/src/display/window_manager/mod.rs
+++ b/libobs-wrapper/src/display/window_manager/mod.rs
@@ -10,18 +10,26 @@ use windows::{
     core::{w, HSTRING, PCWSTR},
     Win32::{
         Foundation::{COLORREF, HWND, LPARAM, LRESULT, WPARAM},
-        Graphics::{Dwm::DwmIsCompositionEnabled, Gdi::{ValidateRect, HBRUSH}},
+        Graphics::Dwm::DwmIsCompositionEnabled,
         System::{
             LibraryLoader::{GetModuleHandleA, GetModuleHandleW},
             SystemInformation::{GetVersionExW, OSVERSIONINFOW},
         },
         UI::WindowsAndMessaging::{
-            CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW, GetWindowLongPtrW, LoadCursorW, PostQuitMessage, RegisterClassExW, SetLayeredWindowAttributes, SetParent, SetWindowLongPtrW, TranslateMessage, CS_HREDRAW, CS_NOCLOSE, CS_OWNDC, CS_VREDRAW, GWL_EXSTYLE, GWL_STYLE, HICON, HTTRANSPARENT, IDC_ARROW, LWA_ALPHA, MSG, WINDOW_EX_STYLE, WM_DESTROY, WM_NCHITTEST, WM_PAINT, WNDCLASSEXW, WS_CHILD, WS_EX_COMPOSITED, WS_EX_LAYERED, WS_EX_TRANSPARENT, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_VISIBLE
+            CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
+            GetWindowLongPtrW, LoadCursorW, RegisterClassExW, SetLayeredWindowAttributes,
+            SetParent, SetWindowLongPtrW, TranslateMessage, CS_HREDRAW, CS_NOCLOSE, CS_OWNDC,
+            CS_VREDRAW, GWL_EXSTYLE, GWL_STYLE, HTTRANSPARENT, IDC_ARROW, LWA_ALPHA, MSG,
+            WM_NCHITTEST, WNDCLASSEXW, WS_CHILD, WS_EX_COMPOSITED, WS_EX_LAYERED,
+            WS_EX_TRANSPARENT, WS_POPUP, WS_VISIBLE,
         },
     },
 };
 
-use crate::unsafe_send::WrappedHWND;
+use crate::unsafe_send::{WrappedHWND, WrappedObsDisplay};
+
+mod position_trait;
+pub use position_trait::WindowPositionTrait;
 
 extern "system" fn wndproc(
     window: HWND,
@@ -59,7 +67,7 @@ lazy_static! {
     static ref REGISTERED_CLASS: AtomicBool = AtomicBool::new(false);
 }
 
-pub fn try_register_class() -> windows::core::Result<()> {
+fn try_register_class() -> windows::core::Result<()> {
     if REGISTERED_CLASS.load(Ordering::Relaxed) {
         return Ok(());
     }
@@ -100,11 +108,20 @@ pub fn try_register_class() -> windows::core::Result<()> {
 
 #[derive(Debug)]
 pub struct DisplayWindowManager {
-    hwnd: WrappedHWND,
-    width: i32,
-    height: i32,
+    // Shouldn't really be needed
+    _message_thread: std::thread::JoinHandle<()>,
     should_exit: Arc<AtomicBool>,
-    message_thread: std::thread::JoinHandle<()>,
+    hwnd: WrappedHWND,
+
+    x: i32,
+    y: i32,
+
+    width: u32,
+    height: u32,
+
+    render_at_bottom: bool,
+
+    pub(super) obs_display: Option<WrappedObsDisplay>
 }
 
 impl DisplayWindowManager {
@@ -112,8 +129,8 @@ impl DisplayWindowManager {
         parent: HWND,
         x: i32,
         y: i32,
-        width: i32,
-        height: i32,
+        width: u32,
+        height: u32,
     ) -> windows::core::Result<Self> {
         log::trace!("Registering class...");
         try_register_class()?;
@@ -131,18 +148,24 @@ impl DisplayWindowManager {
         let window_name = HSTRING::from("LibObsChildWindowPreview");
         log::trace!("Creating window...");
 
-        log::debug!("Creating window with x: {}, y: {}, width: {}, height: {}", x, y, width, height);
+        log::debug!(
+            "Creating window with x: {}, y: {}, width: {}, height: {}",
+            x,
+            y,
+            width,
+            height
+        );
         let window = unsafe {
             // More at https://github.com/stream-labs/obs-studio-node/blob/4e19d8a61a4dd7744e75ce77624c664e371cbfcf/obs-studio-server/source/nodeobs_display.cpp#L170
             CreateWindowExW(
                 WS_EX_LAYERED,
                 &class_name,
                 &window_name,
-                WS_POPUP | WS_VISIBLE,//WS_POPUP,
+                WS_POPUP | WS_VISIBLE, //WS_POPUP,
                 x,
                 y,
-                width,
-                height,
+                width as i32,
+                height as i32,
                 parent,
                 None,
                 instance,
@@ -190,11 +213,15 @@ impl DisplayWindowManager {
         });
 
         Ok(Self {
+            x,
+            y,
             width,
             height,
             hwnd: WrappedHWND(window),
             should_exit,
-            message_thread,
+            _message_thread: message_thread,
+            render_at_bottom: false,
+            obs_display: None
         })
     }
 

--- a/libobs-wrapper/src/display/window_manager/position_trait.rs
+++ b/libobs-wrapper/src/display/window_manager/position_trait.rs
@@ -1,0 +1,91 @@
+use libobs::obs_display_resize;
+use windows::Win32::{
+    Foundation::HWND,
+    Graphics::Gdi::{RedrawWindow, RDW_ERASE, RDW_INVALIDATE},
+    UI::WindowsAndMessaging::{
+        SetWindowPos, HWND_BOTTOM, SWP_NOACTIVATE, SWP_NOCOPYBITS, SWP_NOSIZE, SWP_NOZORDER,
+        SWP_SHOWWINDOW,
+    },
+};
+
+use super::DisplayWindowManager;
+
+pub trait WindowPositionTrait {
+    fn set_render_at_bottom(&mut self, render_at_bottom: bool);
+    fn get_render_at_bottom(&self) -> bool;
+    fn set_pos(&mut self, x: i32, y: i32) -> windows::core::Result<()>;
+    fn set_size(&mut self, width: u32, height: u32) -> windows::core::Result<()>;
+    fn get_pos(&self) -> (i32, i32);
+    fn get_size(&self) -> (u32, u32);
+}
+
+impl WindowPositionTrait for DisplayWindowManager {
+    fn set_render_at_bottom(&mut self, render_at_bottom: bool) {
+        self.render_at_bottom = render_at_bottom;
+    }
+
+    fn get_render_at_bottom(&self) -> bool {
+        self.render_at_bottom
+    }
+
+    fn set_pos(&mut self, x: i32, y: i32) -> windows::core::Result<()> {
+        assert!(
+            self.obs_display.is_some(),
+            "Invalid state. The display should have been created and set, but it wasn't."
+        );
+
+        let insert_after = if self.render_at_bottom {
+            HWND_BOTTOM
+        } else {
+            HWND::default()
+        };
+
+        self.x = x;
+        self.y = y;
+
+        unsafe {
+            let flags = SWP_NOCOPYBITS | SWP_NOSIZE | SWP_NOACTIVATE;
+            // Just use dummy values as size is not changed
+            SetWindowPos(self.hwnd.0, insert_after, x, y, 1 as i32, 1 as i32, flags)?;
+        }
+
+        Ok(())
+    }
+
+    fn get_pos(&self) -> (i32, i32) {
+        (self.x, self.y)
+    }
+
+    fn get_size(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+
+    fn set_size(&mut self, width: u32, height: u32) -> windows::core::Result<()> {
+        assert!(
+            self.obs_display.is_some(),
+            "Invalid state. The display should have been created and set, but it wasn't."
+        );
+
+        self.width = width;
+        self.height = height;
+
+        let pointer = self.obs_display.as_ref().unwrap().0;
+        unsafe {
+            SetWindowPos(
+                self.hwnd.0,
+                None,
+                self.x,
+                self.y,
+                width as i32,
+                height as i32,
+                SWP_NOCOPYBITS | SWP_NOACTIVATE | SWP_NOZORDER | SWP_SHOWWINDOW,
+            )?;
+
+            let _ = RedrawWindow(self.hwnd.0, None, None, RDW_ERASE | RDW_INVALIDATE);
+
+            obs_display_resize(pointer, width, height);
+        }
+
+        Ok(())
+    }
+}

--- a/libobs-wrapper/src/display/window_manager/position_trait.rs
+++ b/libobs-wrapper/src/display/window_manager/position_trait.rs
@@ -8,84 +8,96 @@ use windows::Win32::{
     },
 };
 
-use super::DisplayWindowManager;
+use crate::display::ObsDisplay;
 
 pub trait WindowPositionTrait {
     fn set_render_at_bottom(&mut self, render_at_bottom: bool);
     fn get_render_at_bottom(&self) -> bool;
     fn set_pos(&mut self, x: i32, y: i32) -> windows::core::Result<()>;
     fn set_size(&mut self, width: u32, height: u32) -> windows::core::Result<()>;
+    fn set_scale(&mut self, scale: f32) -> windows::core::Result<()>;
+
     fn get_pos(&self) -> (i32, i32);
     fn get_size(&self) -> (u32, u32);
+    fn get_scale(&self) -> f32;
 }
 
-impl WindowPositionTrait for DisplayWindowManager {
+impl WindowPositionTrait for ObsDisplay {
     fn set_render_at_bottom(&mut self, render_at_bottom: bool) {
-        self.render_at_bottom = render_at_bottom;
+        self.manager.render_at_bottom = render_at_bottom;
     }
 
     fn get_render_at_bottom(&self) -> bool {
-        self.render_at_bottom
+        self.manager.render_at_bottom
     }
 
     fn set_pos(&mut self, x: i32, y: i32) -> windows::core::Result<()> {
         assert!(
-            self.obs_display.is_some(),
+            self.manager.obs_display.is_some(),
             "Invalid state. The display should have been created and set, but it wasn't."
         );
 
-        let insert_after = if self.render_at_bottom {
+        let insert_after = if self.manager.render_at_bottom {
             HWND_BOTTOM
         } else {
             HWND::default()
         };
 
-        self.x = x;
-        self.y = y;
+        self.manager.x = x;
+        self.manager.y = y;
 
         unsafe {
             let flags = SWP_NOCOPYBITS | SWP_NOSIZE | SWP_NOACTIVATE;
             // Just use dummy values as size is not changed
-            SetWindowPos(self.hwnd.0, insert_after, x, y, 1 as i32, 1 as i32, flags)?;
+            SetWindowPos(self.manager.hwnd.0, insert_after, x, y, 1 as i32, 1 as i32, flags)?;
         }
 
         Ok(())
     }
 
     fn get_pos(&self) -> (i32, i32) {
-        (self.x, self.y)
+        (self.manager.x, self.manager.y)
     }
 
     fn get_size(&self) -> (u32, u32) {
-        (self.width, self.height)
+        (self.manager.width, self.manager.height)
     }
 
     fn set_size(&mut self, width: u32, height: u32) -> windows::core::Result<()> {
         assert!(
-            self.obs_display.is_some(),
+            self.manager.obs_display.is_some(),
             "Invalid state. The display should have been created and set, but it wasn't."
         );
 
-        self.width = width;
-        self.height = height;
+        self.manager.width = width;
+        self.manager.height = height;
 
-        let pointer = self.obs_display.as_ref().unwrap().0;
+        let pointer = self.manager.obs_display.as_ref().unwrap().0;
         unsafe {
             SetWindowPos(
-                self.hwnd.0,
+                self.manager.hwnd.0,
                 None,
-                self.x,
-                self.y,
+                self.manager.x,
+                self.manager.y,
                 width as i32,
                 height as i32,
                 SWP_NOCOPYBITS | SWP_NOACTIVATE | SWP_NOZORDER | SWP_SHOWWINDOW,
             )?;
 
-            let _ = RedrawWindow(self.hwnd.0, None, None, RDW_ERASE | RDW_INVALIDATE);
+            let _ = RedrawWindow(self.manager.hwnd.0, None, None, RDW_ERASE | RDW_INVALIDATE);
 
             obs_display_resize(pointer, width, height);
         }
 
         Ok(())
+    }
+
+    fn set_scale(&mut self, scale: f32) -> windows::core::Result<()> {
+        self.manager.scale = scale;
+        Ok(())
+    }
+
+    fn get_scale(&self) -> f32 {
+        self.manager.scale
     }
 }

--- a/libobs-wrapper/src/display/window_manager/show_hide.rs
+++ b/libobs-wrapper/src/display/window_manager/show_hide.rs
@@ -1,0 +1,30 @@
+use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE, SW_SHOWNA};
+
+use crate::display::ObsDisplay;
+
+pub trait ShowHideTrait {
+    fn show(&mut self);
+    fn hide(&mut self);
+    fn is_visible(&self) -> bool;
+}
+
+impl ShowHideTrait for ObsDisplay {
+    fn show(&mut self) {
+        unsafe {
+            ShowWindow(self.manager.hwnd.0, SW_SHOWNA);
+        }
+        self.manager.is_hidden = false;
+    }
+
+    fn hide(&mut self) {
+        unsafe {
+            ShowWindow(self.manager.hwnd.0, SW_HIDE);
+        }
+
+        self.manager.is_hidden = true;
+    }
+
+    fn is_visible(&self) -> bool {
+        !self.manager.is_hidden
+    }
+}

--- a/libobs-wrapper/src/utils/error.rs
+++ b/libobs-wrapper/src/utils/error.rs
@@ -26,7 +26,9 @@ pub enum ObsError {
     OutputStopFailure(Option<String>),
 
     /// Native error from the Windows API when creating a display
-    DisplayCreationError(windows::core::Error)
+    DisplayCreationError(windows::core::Error),
+
+    OutputSaveBufferFailure(String)
 }
 
 impl Display for ObsError {
@@ -44,6 +46,7 @@ impl Display for ObsError {
             ObsError::OutputStartFailure(s) => write!(f, "Output failed to start. Error is {:?}", s),
             ObsError::OutputStopFailure(s) => write!(f, "Output failed to stop. Error is {:?}", s),
             ObsError::DisplayCreationError(e) => write!(f, "Native error from the Windows API when creating a display: {:?}", e),
+            ObsError::OutputSaveBufferFailure(e) => write!(f, "Couldn't save output buffer: {:?}", e),
         }
     }
 }


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve functionality and maintainability. The most important changes include adding a new output module, updating the `build_obs` function to handle new exclusions, and refactoring the `ObsDisplay` class for better initialization and rendering.

### New Features and Modules:
* Added a new `output` module in `libobs-sources` to handle different output types using macros. (`libobs-sources/src/output.rs`)
* Introduced a `ReplayBufferOutput` trait and its implementation to manage replay buffer operations. (`libobs-wrapper/src/data/output/replay_buffer.rs`)

### Functionality Improvements:
* Updated the `build_obs` function to include "qt6" in the list of unnecessary files to exclude. (`cargo-obs-build/src/main.rs`)
* Modified the exclusion logic in the `build_obs` function to be case-insensitive. (`cargo-obs-build/src/main.rs`)

### Refactoring and Code Cleanup:
* Refactored the `ObsDisplay` class to separate its creation and initialization logic, improving readability and maintainability. (`libobs-wrapper/src/display/mod.rs`)
* Removed unused scale property from `ObsDisplayCreationData` and related methods. (`libobs-wrapper/src/display/creation_data.rs`) 

### Minor Changes:
* Updated the version of `cargo-obs-build` from `0.1.7` to `0.1.8`. (`cargo-obs-build/Cargo.toml`)
* Commented out unused `video_source_info` in `run_basic_obs` function. (`libobs-segfault-trace/src/main.rs`)
