### PR TITLE
fix monitor_capture 'black screen' bug

### DIFF
--- a/libobs-sources/src/windows/sources/monitor_capture.rs
+++ b/libobs-sources/src/windows/sources/monitor_capture.rs
@@ -22,7 +22,7 @@ define_object_manager!(
         /// Compatibility mode for the monitor capture source.
         compatibility: bool,
 
-        #[obs_property(type_t="enum")]
+        #[obs_property(type_t="enum", settings_key = "method")]
         /// Sets the capture method for the monitor capture source.
         capture_method: ObsDisplayCaptureMethod,
     }

--- a/libobs-sources/tests/windows/test_monitor_capture.rs
+++ b/libobs-sources/tests/windows/test_monitor_capture.rs
@@ -22,6 +22,7 @@ pub async fn monitor_test() {
     println!("Using monitor {:?}", monitor);
     MonitorCaptureSourceBuilder::new("monitor_test")
         .set_monitor(&monitor)
+        // Set the method as WGC (based on hit and trial)
         .set_capture_method(ObsDisplayCaptureMethod::MethodWgc)
         .add_to_scene(&mut scene)
         .unwrap();

--- a/libobs/examples/raw_calls.rs
+++ b/libobs/examples/raw_calls.rs
@@ -146,6 +146,12 @@ fn main() {
             CString::new("\\\\?\\DISPLAY#AOC2402#7&11e44168&3&UID256#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}").unwrap().as_ptr(),
         );
 
+        libobs::obs_data_set_int(
+            video_source_settings,
+            CString::new("method").unwrap().as_ptr(),
+            libobs::window_capture_method_METHOD_WGC.into(),
+        );
+
         // SETUP NEW VIDEO SOURCE
         let video_source = libobs::obs_source_create(
             #[cfg(target_os = "windows")]


### PR DESCRIPTION
- OBS expects `method` as required field in settings while creating `monitor_capture` source along with `monitor_id`.
- In my case, even when the resultant window capture method is `DXGI`, passing the same was resulting in failure, passing `WGC` works and it automatically updates it to DXGI while saving.
- We might need to make both `monitor_id` and `method` as compulsory field so setting up these will not be missed.