### PR TITLE
docs: add missing --out-dir for obs-build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ libobs-version="31.0.3"
 Install OBS in your target directory. This uses the original signed OBS binaries.
 ```bash
 # for debugging
-cargo obs-build target/debug
+cargo obs-build --out-dir target/debug
 # for release
-cargo obs-build target/release
+cargo obs-build --out-dir target/release
 # for testing
-cargo obs-build target/(debug|release)/deps
+cargo obs-build --out-dir target/(debug|release)/deps
 ```
 
 

--- a/libobs-wrapper/README.md
+++ b/libobs-wrapper/README.md
@@ -42,13 +42,13 @@ Install OBS in your target directory:
 
 ```bash
 # For debug builds
-cargo obs-build target/debug
+cargo obs-build --out-dir target/debug
 
 # For release builds
-cargo obs-build target/release
+cargo obs-build --out-dir target/release
 
 # For testing
-cargo obs-build target/(debug|release)/deps
+cargo obs-build --out-dir target/(debug|release)/deps
 ```
 
 ### Option 2: Using the OBS Bootstrapper (Recommended for distribution)


### PR DESCRIPTION
Noticed that this was out of date when setting up the binaries locally for development 🙂 