### PR TITLE
fix(wrapper): add full list of encoders, including deprecations

### DIFF
--- a/libobs-wrapper/src/encoders/enums.rs
+++ b/libobs-wrapper/src/encoders/enums.rs
@@ -9,7 +9,7 @@ macro_rules! encoder_enum {
         pub enum $name {
             $(
                 $(
-                    #[doc = concat!("From plugin: `", $plugin, "`")]
+                    #[doc = "From plugin: `" $plugin "`"]
                     $(#[$attr])*
                     [<$variant:upper>],
                 )*


### PR DESCRIPTION
We got got by using `FFMPEG_NVENC`, which is deprecated and uses an older and slower codepath. I was able to work around this with `Other`, but I figured I'd spend the time to get the encoder list fully synced up with OBS proper.

Unfortunately, this process can't easily be automated (unless your automation involves a LLM); there are a few dynamically-assigned encoders, as well as encoders that don't use the struct init syntax. Still, the `rg` catches all of them: they just need to be manually investigated.

p.s. there are a *lot* of warnings, and not all of the tests compile. Probably need to tighten up the CI at some point and fix those at some point.