### PR TITLE
fix: add game capture audio property

### DIFF
--- a/libobs-simple/src/sources/windows/sources/game_capture.rs
+++ b/libobs-simple/src/sources/windows/sources/game_capture.rs
@@ -117,6 +117,7 @@ define_object_manager!(
         /// Whether to capture audio from window source (BETA) <br>
         /// When enabled, creates an "Application Audio Capture" source that automatically updates to the currently captured window/application. <br>
         /// Note that if Desktop Audio is configured, this could result in doubled audio.
+        #[obs_property(type_t = "bool")]
         capture_audio: bool,
     }
 );


### PR DESCRIPTION
Adds a missing `obs_property`; without this, the setter was not generated, so there was no way to set it externally.